### PR TITLE
Feature/swagger setting

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-* @mkSpace @han51361 @god9599
+* @mkSpace @han51361 @god9599 @wjdrbs96

--- a/build.gradle
+++ b/build.gradle
@@ -39,8 +39,7 @@ subprojects {
         developmentOnly 'org.springframework.boot:spring-boot-devtools'
         annotationProcessor 'org.projectlombok:lombok'
         testImplementation 'org.springframework.boot:spring-boot-starter-test'
-        implementation 'io.springfox:springfox-swagger-ui:2.9.2'
-        implementation 'io.springfox:springfox-swagger2:2.9.2'
+        implementation 'io.springfox:springfox-boot-starter:3.0.0'
     }
 
     test {

--- a/build.gradle
+++ b/build.gradle
@@ -39,6 +39,8 @@ subprojects {
         developmentOnly 'org.springframework.boot:spring-boot-devtools'
         annotationProcessor 'org.projectlombok:lombok'
         testImplementation 'org.springframework.boot:spring-boot-starter-test'
+        implementation 'io.springfox:springfox-swagger-ui:2.9.2'
+        implementation 'io.springfox:springfox-swagger2:2.9.2'
     }
 
     test {

--- a/jsmr-api/src/main/java/mashup/spring/jsmr/config/SwaggerConfig.java
+++ b/jsmr-api/src/main/java/mashup/spring/jsmr/config/SwaggerConfig.java
@@ -1,0 +1,41 @@
+package mashup.spring.jsmr.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import springfox.documentation.builders.ApiInfoBuilder;
+import springfox.documentation.builders.PathSelectors;
+import springfox.documentation.builders.RequestHandlerSelectors;
+import springfox.documentation.service.ApiInfo;
+import springfox.documentation.spi.DocumentationType;
+import springfox.documentation.spring.web.plugins.Docket;
+import springfox.documentation.swagger2.annotations.EnableSwagger2;
+
+
+@Configuration
+@EnableSwagger2
+public class SwaggerConfig {
+    private static final String API_NAME = "JSMR-API";
+    private static final String API_VERSION = "v1";
+    private static final String API_DESCRIPTION = "정신머리 API 명세";
+
+    @Bean
+    public Docket apiV1(){
+        return new Docket(DocumentationType.SWAGGER_2)
+                .apiInfo(apiInfo())
+                .select()
+                .apis(RequestHandlerSelectors.basePackage("mashup.spring.jsmr"))
+                .paths(PathSelectors.any())
+                .build();
+    }
+
+    private ApiInfo apiInfo(){
+        return new ApiInfoBuilder()
+                .title(API_NAME)
+                .version(API_VERSION)
+                .description(API_DESCRIPTION)
+                .build();
+    }
+
+
+
+}

--- a/jsmr-api/src/main/resources/application.yml
+++ b/jsmr-api/src/main/resources/application.yml
@@ -1,0 +1,4 @@
+spring:
+  mvc:
+    pathmatch:
+      matching-strategy: ant_path_matcher


### PR DESCRIPTION
swagger-ui  접속 : http://localhost:8080/swagger-ui/ 
- swagger 지원 springfox 3.x 와 springboot 버전 호환 문제 
  -  yml 에 spring.mvc match 전략 변경 
  - 참고 ref: [stackoverflow](https://stackoverflow.com/questions/70036953/springboot-2-6-0-spring-fox-3-failed-to-start-bean-documentationpluginsboot) , [ref2](https://velog.io/@ohjinseo/SpringBoot-2.6-%EC%9D%B4%EC%83%81-springfox-swagger3.0-%EC%A0%81%EC%9A%A9-%EC%8B%9C-%EC%97%90%EB%9F%AC-%ED%95%B4%EA%B2%B0)