### PR TITLE
feat: jwt add

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -39,6 +39,8 @@ subprojects {
         compileOnly 'org.projectlombok:lombok'
         annotationProcessor 'org.projectlombok:lombok'
 
+        annotationProcessor 'org.springframework.boot:spring-boot-configuration-processor'
+
         developmentOnly 'org.springframework.boot:spring-boot-devtools'
         testImplementation 'org.springframework.boot:spring-boot-starter-test'
     }

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,1 +1,2 @@
 swaggerVersion=3.0.0
+jwtVersion=0.9.1

--- a/jsmr-api/build.gradle
+++ b/jsmr-api/build.gradle
@@ -1,6 +1,10 @@
 dependencies {
     implementation project(":jsmr-domain")
     implementation "io.springfox:springfox-boot-starter:$swaggerVersion"
+
+    // JWT
+    implementation 'javax.xml.bind:jaxb-api'
+    implementation "io.jsonwebtoken:jjwt:$jwtVersion"
 }
 
 test {

--- a/jsmr-api/src/main/java/mashup/spring/jsmr/adapter/api/AdviceController.java
+++ b/jsmr-api/src/main/java/mashup/spring/jsmr/adapter/api/AdviceController.java
@@ -1,13 +1,25 @@
 package mashup.spring.jsmr.adapter.api;
 
+import lombok.RequiredArgsConstructor;
+import mashup.spring.jsmr.adapter.api.jwt.TokenResponseDTO;
+import mashup.spring.jsmr.adapter.infrastructure.jwt.JwtProvider;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RestController;
 
+@RequiredArgsConstructor
 @RestController
 public class AdviceController {
+
+    private final JwtProvider jwtProvider;
 
     @GetMapping("/server-error")
     public void serverError() throws Exception {
         throw new Exception("서버 에러");
     }
+
+    @GetMapping("/jwt-create")
+    public TokenResponseDTO createJwtTest() {
+        return jwtProvider.createTokenResponse(1L);
+    }
+
 }

--- a/jsmr-api/src/main/java/mashup/spring/jsmr/adapter/api/jwt/TokenResponseDTO.java
+++ b/jsmr-api/src/main/java/mashup/spring/jsmr/adapter/api/jwt/TokenResponseDTO.java
@@ -1,0 +1,22 @@
+package mashup.spring.jsmr.adapter.api.jwt;
+
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.util.Date;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+public class TokenResponseDTO {
+
+    private String accessToken;
+    private Date accessTokenExpiredAt;
+
+    @Builder
+    public TokenResponseDTO(String accessToken, Date accessTokenExpiredAt) {
+        this.accessToken = accessToken;
+        this.accessTokenExpiredAt = accessTokenExpiredAt;
+    }
+}

--- a/jsmr-api/src/main/java/mashup/spring/jsmr/adapter/infrastructure/jwt/JwtProperty.java
+++ b/jsmr-api/src/main/java/mashup/spring/jsmr/adapter/infrastructure/jwt/JwtProperty.java
@@ -1,0 +1,17 @@
+package mashup.spring.jsmr.adapter.infrastructure.jwt;
+
+import lombok.Getter;
+import lombok.Setter;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.context.annotation.Configuration;
+
+@Getter
+@Setter
+@ConfigurationProperties(prefix = "jwt")
+@Configuration
+public class JwtProperty {
+
+    private String accessTokenSecretKey;
+    private Long accessTokenValidTime;
+}
+

--- a/jsmr-api/src/main/java/mashup/spring/jsmr/adapter/infrastructure/jwt/JwtProvider.java
+++ b/jsmr-api/src/main/java/mashup/spring/jsmr/adapter/infrastructure/jwt/JwtProvider.java
@@ -1,0 +1,68 @@
+package mashup.spring.jsmr.adapter.infrastructure.jwt;
+
+import io.jsonwebtoken.Jwts;
+import io.jsonwebtoken.SignatureAlgorithm;
+import lombok.RequiredArgsConstructor;
+import mashup.spring.jsmr.adapter.api.jwt.TokenResponseDTO;
+import org.springframework.stereotype.Component;
+
+import javax.xml.bind.DatatypeConverter;
+import java.util.Date;
+
+@RequiredArgsConstructor
+@Component
+public class JwtProvider {
+
+    private final JwtProperty jwtProperty;
+
+    private String createToken(final long payload, final String secretKey, final Long tokenValidTime) {
+        return Jwts.builder()
+                .setSubject(String.valueOf(payload))
+                .signWith(SignatureAlgorithm.HS256, secretKey)
+                .setExpiration(new Date(System.currentTimeMillis() + tokenValidTime))
+                .compact();
+    }
+
+    private String createAccessToken(final long payload) {
+        return createToken(payload, jwtProperty.getAccessTokenSecretKey(), jwtProperty.getAccessTokenValidTime());
+    }
+
+    public TokenResponseDTO createTokenResponse(long userId) {
+        var accessToken = createAccessToken(userId);
+
+        return TokenResponseDTO.builder()
+                .accessToken(accessToken)
+                .accessTokenExpiredAt(getTokenExpiredTime(accessToken, jwtProperty.getAccessTokenSecretKey()))
+                .build();
+    }
+
+    private Date getTokenExpiredTime(final String accessToken, final String secretKey) {
+        return Jwts.parser()
+                .setSigningKey(DatatypeConverter.parseBase64Binary(secretKey))
+                .parseClaimsJws(accessToken)
+                .getBody()
+                .getExpiration();
+    }
+
+    public Long getAccessTokenPayload(String accessToken) {
+        var claims = Jwts.parser()
+                .setSigningKey(jwtProperty.getAccessTokenSecretKey())
+                .parseClaimsJws(accessToken)
+                .getBody();
+
+        return Long.parseLong(claims.getSubject());
+    }
+
+    public boolean validateToken(String accessToken) {
+        try {
+            var claims = Jwts.parser()
+                    .setSigningKey(jwtProperty.getAccessTokenSecretKey())
+                    .parseClaimsJws(accessToken);
+
+            return !claims.getBody().getExpiration().before(new Date());
+        } catch (Exception e) {
+            return false;
+        }
+    }
+
+}

--- a/jsmr-api/src/main/resources/application.yml
+++ b/jsmr-api/src/main/resources/application.yml
@@ -2,3 +2,7 @@ spring:
   mvc:
     pathmatch:
       matching-strategy: ant_path_matcher
+
+jwt:
+  access_token_secretKey: asdsaldksjaldjsaldjasdjawldjawldkjawldjalwkdjlawdjawldkjawldjawljdaw
+  access_token_valid_time: 1800000000


### PR DESCRIPTION
- jwt create, decode, validate 하는거 간단하게 작성해보았습니다~ (refreshToken 제외)
- application.yml에 있는 jwt secretKey, validTime은 나중에 중요해질 때 가리는 걸로 해요~

```json

{
  "accessToken": "eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiIxIiwiZXhwIjoxNjU3MTkyODU4fQ.BC7HZyaBij49LQhO5BfjZRkE8KckO8uAywkM3lOXMyk",
  "accessTokenExpiredAt": "2022-07-07T11:20:58.000+00:00"
}
```

위처럼 토큰, 토큰 만료시간이 응답으로 오게 만들었는데요!  이것도 확정은 아니니 일단 틀만 잡아놓고 토욜날 정해보는 걸로 하시죠~