### PR TITLE
feat : 기존 likes query 에러 및 중복 생성 방지 logic 추가 / 결혼식 하객 리스트 조회시 기존 좋아요 날린 사람 필터링 

### DIFF
--- a/jsmr-api/src/main/java/mashup/spring/jsmr/application/profile/ProfileApplicationService.java
+++ b/jsmr-api/src/main/java/mashup/spring/jsmr/application/profile/ProfileApplicationService.java
@@ -8,6 +8,7 @@ import mashup.spring.jsmr.adapter.api.profile.dto.ProfileDetailResponseDTO;
 import mashup.spring.jsmr.adapter.api.profileKeyword.dto.CreateProfileKeywordRequestDTO;
 import mashup.spring.jsmr.domain.answer.Answer;
 import mashup.spring.jsmr.domain.answer.AnswerService;
+import mashup.spring.jsmr.domain.exception.DuplicatedException;
 import mashup.spring.jsmr.domain.keyword.Keyword;
 import mashup.spring.jsmr.domain.keyword.KeywordService;
 import mashup.spring.jsmr.domain.picture.PictureService;
@@ -47,6 +48,9 @@ public class ProfileApplicationService {
     public CreateProfileResponseDTO createProfile(Long userId, CreateProfileRequestDTO createProfileRequestDTO) {
         User user = userService.findById(userId);
 
+        if(profileService.existProfile(user)){
+           throw new DuplicatedException();
+        }
         // profile save
         Profile profile = profileService.createProfile(createProfileRequestDTO.toEntity(user));
 

--- a/jsmr-domain/src/main/java/mashup/spring/jsmr/domain/exception/DuplicatedException.java
+++ b/jsmr-domain/src/main/java/mashup/spring/jsmr/domain/exception/DuplicatedException.java
@@ -1,0 +1,5 @@
+package mashup.spring.jsmr.domain.exception;
+
+public class DuplicatedException extends BusinessException{
+    public DuplicatedException() { super(ExceptionCode.EXIST_ENTITY); }
+}

--- a/jsmr-domain/src/main/java/mashup/spring/jsmr/domain/exception/ExceptionCode.java
+++ b/jsmr-domain/src/main/java/mashup/spring/jsmr/domain/exception/ExceptionCode.java
@@ -17,7 +17,9 @@ public enum ExceptionCode {
     // Security
     FAIL_AUTHENTICATION(HttpStatus.UNAUTHORIZED, "S001", "401 에러 인증 실패"),
     FAIL_AUTHORIZATION(HttpStatus.FORBIDDEN, "S002", "403 에러 권한 없음"),
-    ;
+
+    // Duplicated Entity
+    EXIST_ENTITY(HttpStatus.BAD_REQUEST, "D001", "Already Exist Entity");
 
 
     private final HttpStatus status;

--- a/jsmr-domain/src/main/java/mashup/spring/jsmr/domain/like/LikesRepository.java
+++ b/jsmr-domain/src/main/java/mashup/spring/jsmr/domain/like/LikesRepository.java
@@ -1,5 +1,6 @@
 package mashup.spring.jsmr.domain.like;
 
+import mashup.spring.jsmr.domain.profile.Profile;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
@@ -20,4 +21,6 @@ public interface LikesRepository extends JpaRepository<Likes, Long> {
 
     @Query("select count(l) > 0 from Likes l WHERE l.sender.id = :senderId and l.receiver.id = :receiverId")
     boolean existsBySenderAndReceiver(@Param("senderId") Long senderId, @Param("receiverId") Long receiverId);
+
+    List<Likes> findAllBySender(Profile sender);
 }

--- a/jsmr-domain/src/main/java/mashup/spring/jsmr/domain/like/LikesRepository.java
+++ b/jsmr-domain/src/main/java/mashup/spring/jsmr/domain/like/LikesRepository.java
@@ -2,18 +2,22 @@ package mashup.spring.jsmr.domain.like;
 
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 import java.util.List;
 import java.util.Optional;
 
 public interface LikesRepository extends JpaRepository<Likes, Long> {
     @Query("select l from Likes l JOIN FETCH l.receiver " +
-            "where l.sender = :profileId and l.isMatch = :isMatch")
-    List<Likes> findAllBySenderIdAndIsMatch(Long profileId, Boolean isMatch);
+            "where l.sender.id = :profileId and l.isMatch = :isMatch")
+    List<Likes> findAllBySenderIdAndIsMatch(@Param("profileId") Long profileId, @Param("isMatch") Boolean isMatch);
 
     Optional<Likes> findBySenderIdAndReceiverId(Long senderProfileId, Long receiverProfileId);
 
     @Query("select l from Likes l JOIN FETCH l.sender " +
-            "where l.receiver = :profileId and l.isMatch = :isMatch")
-    List<Likes> findMatchingProfileWithMessage(Long profileId, Boolean isMatch);
+            "where l.receiver.id = :profileId and l.isMatch = :isMatch")
+    List<Likes> findMatchingProfileWithMessage(@Param("profileId") Long profileId, @Param("isMatch") Boolean isMatch);
+
+    @Query("select count(l) > 0 from Likes l WHERE l.sender.id = :senderId and l.receiver.id = :receiverId")
+    boolean existsBySenderAndReceiver(@Param("senderId") Long senderId, @Param("receiverId") Long receiverId);
 }

--- a/jsmr-domain/src/main/java/mashup/spring/jsmr/domain/like/LikesService.java
+++ b/jsmr-domain/src/main/java/mashup/spring/jsmr/domain/like/LikesService.java
@@ -1,6 +1,7 @@
 package mashup.spring.jsmr.domain.like;
 
 import lombok.RequiredArgsConstructor;
+import mashup.spring.jsmr.domain.exception.DuplicatedException;
 import mashup.spring.jsmr.domain.exception.EntityNotFoundException;
 import mashup.spring.jsmr.domain.profile.Profile;
 import mashup.spring.jsmr.domain.profile.ProfileRepository;
@@ -36,6 +37,11 @@ public class LikesService {
 
     @Transactional
     public Likes createLike(final Long profileId, final Long partnerProfileId, String message) {
+
+        if (likesRepository.existsBySenderAndReceiver(profileId, partnerProfileId)){
+            throw new DuplicatedException();
+        }
+
          return likesRepository.findBySenderIdAndReceiverId(partnerProfileId, profileId)
                 .map(likes -> {
                     likes.toMatch();

--- a/jsmr-domain/src/main/java/mashup/spring/jsmr/domain/profile/ProfileRepository.java
+++ b/jsmr-domain/src/main/java/mashup/spring/jsmr/domain/profile/ProfileRepository.java
@@ -1,8 +1,10 @@
 package mashup.spring.jsmr.domain.profile;
 
 import mashup.spring.jsmr.domain.profile.custom.ProfileCustomRepository;
+import mashup.spring.jsmr.domain.user.User;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 import java.util.Optional;
 
@@ -10,6 +12,8 @@ public interface ProfileRepository extends JpaRepository<Profile, Long>, Profile
     
     Optional<Profile> findAllByUserId(Long userId);
 
-    @Query("select p from Profile p join fetch p.user where p.user = :userId")
-    Optional<Profile> findByUserId(Long userId);
+    @Query("select p from Profile p join fetch p.user u where u.id = :userId")
+    Optional<Profile> findByUserId(@Param("userId") Long userId);
+
+    boolean existsProfileByUser(User user);
 }

--- a/jsmr-domain/src/main/java/mashup/spring/jsmr/domain/profile/ProfileService.java
+++ b/jsmr-domain/src/main/java/mashup/spring/jsmr/domain/profile/ProfileService.java
@@ -3,6 +3,7 @@ package mashup.spring.jsmr.domain.profile;
 import lombok.RequiredArgsConstructor;
 import mashup.spring.jsmr.domain.exception.EntityNotFoundException;
 import mashup.spring.jsmr.domain.profileKeyword.ProfileKeywordRepository;
+import mashup.spring.jsmr.domain.user.User;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -28,5 +29,9 @@ public class ProfileService {
 
     public Profile getProfile(final Long userId){
         return profileRepository.findByUserId(userId).orElseThrow(EntityNotFoundException::new);
+    }
+
+    public boolean existProfile(final User user){
+        return profileRepository.existsProfileByUser(user);
     }
 }

--- a/jsmr-domain/src/main/java/mashup/spring/jsmr/domain/weddingChannel/WeddingChannelRepository.java
+++ b/jsmr-domain/src/main/java/mashup/spring/jsmr/domain/weddingChannel/WeddingChannelRepository.java
@@ -3,10 +3,19 @@ package mashup.spring.jsmr.domain.weddingChannel;
 import mashup.spring.jsmr.domain.profile.Profile;
 import mashup.spring.jsmr.domain.weddingChannel.custom.WeddingChannelCustomRepository;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 import java.util.List;
 
 public interface WeddingChannelRepository extends JpaRepository<WeddingChannel, Long>, WeddingChannelCustomRepository {
 
     List<WeddingChannel> findAllByProfile(Profile profile);
+
+    @Query("select w from WeddingChannel w " +
+            "join fetch w.profile " +
+            "where w.profile.gender <> :#{#profile.gender} " +
+            "and w.profile.id <> :#{#profile.id} " +
+            "and w.profile.id not in :likedList")
+    List<WeddingChannel> findByProfile(@Param("profile") Profile profile, @Param("likedList") List<Long> likedList);
 }

--- a/jsmr-domain/src/main/java/mashup/spring/jsmr/domain/weddingChannel/WeddingChannelService.java
+++ b/jsmr-domain/src/main/java/mashup/spring/jsmr/domain/weddingChannel/WeddingChannelService.java
@@ -2,6 +2,7 @@ package mashup.spring.jsmr.domain.weddingChannel;
 
 import lombok.RequiredArgsConstructor;
 import mashup.spring.jsmr.domain.exception.EntityNotFoundException;
+import mashup.spring.jsmr.domain.like.LikesRepository;
 import mashup.spring.jsmr.domain.profile.Profile;
 import mashup.spring.jsmr.domain.profile.ProfileRepository;
 import mashup.spring.jsmr.domain.wedding.Role;
@@ -11,6 +12,7 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
+import java.util.stream.Collectors;
 
 @Transactional(readOnly = true)
 @RequiredArgsConstructor
@@ -21,10 +23,17 @@ public class WeddingChannelService {
     private final WeddingRepository weddingRepository;
     private final ProfileRepository profileRepository;
 
+    private final LikesRepository likesRepository;
+
     public List<WeddingChannel> getWeddingGuests(final Long userId) {
         Profile profile = profileRepository.findAllByUserId(userId)
                 .orElseThrow(EntityNotFoundException::new);
-        return weddingChannelRepository.findByWeddingGuestsByFetch(profile);
+
+        List<Long> postedLikeList = likesRepository.findAllBySender(profile).stream()
+                .map(likes -> likes.getReceiver().getId())
+                .collect(Collectors.toList());
+
+        return weddingChannelRepository.findByProfile(profile, postedLikeList);
     }
 
     @Transactional


### PR DESCRIPTION
- 기존 like api 쿼리 날릴 때 sql 쿼리 문제가 있어서  수정
- like api 부분 다시 테스트하면서 동일하게 요청시 엔티티 재생성이 가능한 부분이 있어서 이부분도 로직으로 throw 날릴 수 있게 변경  
- weddingChannel API 중 하객 리스트 전체 조회시, 기존에 좋아요를 보낸 사람은 조회 안되도록 쿼리 수정 