### PR TITLE
update : 하객리스트 조회시, response 빈 list 예외 처리

### DIFF
--- a/jsmr-api/http/weddingChannel/guestList.http
+++ b/jsmr-api/http/weddingChannel/guestList.http
@@ -1,0 +1,3 @@
+GET {{api}}/api/v1/wedding/guests
+Authorization: Bearer {{Authorization}}
+

--- a/jsmr-domain/src/main/java/mashup/spring/jsmr/domain/weddingChannel/WeddingChannelService.java
+++ b/jsmr-domain/src/main/java/mashup/spring/jsmr/domain/weddingChannel/WeddingChannelService.java
@@ -30,6 +30,9 @@ public class WeddingChannelService {
                 .map(likes -> likes.getReceiver().getId())
                 .collect(Collectors.toList());
 
+        if (postedLikeList.isEmpty()){ //빈 경우 query : not in (null) 방지
+            postedLikeList.add(-1L);
+        }
         return weddingChannelRepository.findByProfile(profile, postedLikeList);
     }
 }


### PR DESCRIPTION
- 게스트 조회시, 이전에 좋아요한 리스트 없을 시 
```sql 
not in (null)
```
해당 쿼리로 실행되어 전체 결과 false 로 반환되는 문제 처리 