### PR TITLE
feat : update like jpql -> querydsl

### DIFF
--- a/jsmr-api/http/likes/createLikes.http
+++ b/jsmr-api/http/likes/createLikes.http
@@ -1,0 +1,9 @@
+### 좋아요 생성
+POST {{api}}/api/v1/like
+Content-Type: application/json
+
+{
+  "message": "나두 좋아~",
+  "receiverProfileId": 1,
+  "senderProfileId": 2
+}

--- a/jsmr-api/http/likes/getLikeProfiles.http
+++ b/jsmr-api/http/likes/getLikeProfiles.http
@@ -1,0 +1,3 @@
+### 좋아요한 프로필 조회
+GET {{api}}/api/v1/like/profiles
+Authorization: Bearer {{Authorization}}

--- a/jsmr-api/http/likes/getMatchingProfiles.http
+++ b/jsmr-api/http/likes/getMatchingProfiles.http
@@ -1,0 +1,3 @@
+### 매칭된 프로필 조회
+GET {{api}}/api/v1/like/matching-profiles
+Authorization: Bearer {{Authorization}}

--- a/jsmr-domain/src/main/java/mashup/spring/jsmr/domain/like/LikesRepository.java
+++ b/jsmr-domain/src/main/java/mashup/spring/jsmr/domain/like/LikesRepository.java
@@ -1,26 +1,15 @@
 package mashup.spring.jsmr.domain.like;
 
+import mashup.spring.jsmr.domain.like.custom.LikeCustomRepository;
 import mashup.spring.jsmr.domain.profile.Profile;
 import org.springframework.data.jpa.repository.JpaRepository;
-import org.springframework.data.jpa.repository.Query;
-import org.springframework.data.repository.query.Param;
 
 import java.util.List;
 import java.util.Optional;
 
-public interface LikesRepository extends JpaRepository<Likes, Long> {
-    @Query("select l from Likes l JOIN FETCH l.receiver " +
-            "where l.sender.id = :profileId and l.isMatch = :isMatch")
-    List<Likes> findAllBySenderIdAndIsMatch(@Param("profileId") Long profileId, @Param("isMatch") Boolean isMatch);
+public interface LikesRepository extends JpaRepository<Likes, Long>, LikeCustomRepository {
 
     Optional<Likes> findBySenderIdAndReceiverId(Long senderProfileId, Long receiverProfileId);
-
-    @Query("select l from Likes l JOIN FETCH l.sender " +
-            "where l.receiver.id = :profileId and l.isMatch = :isMatch")
-    List<Likes> findMatchingProfileWithMessage(@Param("profileId") Long profileId, @Param("isMatch") Boolean isMatch);
-
-    @Query("select count(l) > 0 from Likes l WHERE l.sender.id = :senderId and l.receiver.id = :receiverId")
-    boolean existsBySenderAndReceiver(@Param("senderId") Long senderId, @Param("receiverId") Long receiverId);
 
     List<Likes> findAllBySender(Profile sender);
 }

--- a/jsmr-domain/src/main/java/mashup/spring/jsmr/domain/like/custom/LikeCustomRepository.java
+++ b/jsmr-domain/src/main/java/mashup/spring/jsmr/domain/like/custom/LikeCustomRepository.java
@@ -1,0 +1,13 @@
+package mashup.spring.jsmr.domain.like.custom;
+
+import mashup.spring.jsmr.domain.like.Likes;
+
+import java.util.List;
+
+public interface LikeCustomRepository {
+    List<Likes> findAllBySenderIdAndIsMatch(Long profileId, Boolean isMatch);
+
+    List<Likes> findMatchingProfileWithMessage(Long profileId, Boolean isMatch);
+
+    boolean existsBySenderAndReceiver(Long senderId, Long receiverId);
+}

--- a/jsmr-domain/src/main/java/mashup/spring/jsmr/domain/like/custom/LikeCustomRepositoryImpl.java
+++ b/jsmr-domain/src/main/java/mashup/spring/jsmr/domain/like/custom/LikeCustomRepositoryImpl.java
@@ -1,0 +1,67 @@
+package mashup.spring.jsmr.domain.like.custom;
+
+import com.querydsl.jpa.JPQLQuery;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import mashup.spring.jsmr.domain.like.Likes;
+import mashup.spring.jsmr.domain.like.QLikes;
+import mashup.spring.jsmr.domain.profile.QProfile;
+import org.springframework.data.jpa.repository.support.QuerydslRepositorySupport;
+
+import java.util.List;
+
+public class LikeCustomRepositoryImpl extends QuerydslRepositorySupport implements LikeCustomRepository {
+
+    private final JPAQueryFactory jpaQueryFactory;
+
+    private final QLikes likes = QLikes.likes;
+
+    private final QProfile profile = QProfile.profile;
+
+    public LikeCustomRepositoryImpl(JPAQueryFactory jpaQueryFactory1) {
+        super(Likes.class);
+        this.jpaQueryFactory = jpaQueryFactory1;
+    }
+
+    @Override
+    public List<Likes> findAllBySenderIdAndIsMatch(Long profileId, Boolean isMatch) {
+        return setReceiverFetchJoinQuery()
+                .where(
+                        likes.sender.id.eq(profileId),
+                        likes.isMatch.eq(isMatch)
+                )
+                .fetch();
+    }
+
+    @Override
+    public List<Likes> findMatchingProfileWithMessage(Long profileId, Boolean isMatch) {
+        return setSenderFetchJoinQuery()
+                .where(
+                        likes.receiver.id.eq(profileId),
+                        likes.isMatch.eq(isMatch)
+                )
+                .fetch();
+    }
+
+    @Override
+    public boolean existsBySenderAndReceiver(Long senderId, Long receiverId) {
+        return from(this.likes)
+                .where(
+                        likes.sender.id.eq(senderId),
+                        likes.receiver.id.eq(receiverId)
+                )
+                .fetchCount() > 0;
+    }
+
+    private JPQLQuery<Likes> setReceiverFetchJoinQuery() {
+        return jpaQueryFactory.selectFrom(this.likes)
+                .join(likes.receiver, profile)
+                .fetchJoin();
+    }
+
+    private JPQLQuery<Likes> setSenderFetchJoinQuery() {
+        return jpaQueryFactory.selectFrom(this.likes)
+                .join(likes.sender, profile)
+                .fetchJoin();
+    }
+
+}


### PR DESCRIPTION
- 기존 like jpql 에서 querydsl로 바꾸었습니다.
- http-client 로 좋아요 create -> 좋아요 프로필 조회 -> 상대방 역 좋아요 create -> 매칭된 프로필 조회 테스트 완료 